### PR TITLE
Add Dark Mode and High-DPI Support

### DIFF
--- a/SysBot.Pokemon.WinForms/Controls/CollectionDescriptionProvider.cs
+++ b/SysBot.Pokemon.WinForms/Controls/CollectionDescriptionProvider.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Linq;
+
+namespace SysBot.Pokemon.WinForms;
+
+public class CollectionDescriptionProvider(Type type) : TypeDescriptionProvider(TypeDescriptor.GetProvider(type))
+{
+    private readonly TypeDescriptionProvider _baseProvider = TypeDescriptor.GetProvider(type);
+
+    public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object? instance)
+        => new DrawableCollectionEditorDescriptor(_baseProvider.GetTypeDescriptor(objectType, instance)!);
+}
+
+public class DrawableCollectionEditorDescriptor(ICustomTypeDescriptor parent) : CustomTypeDescriptor(parent)
+{
+    public override PropertyDescriptorCollection GetProperties(Attribute[]? attributes)
+    {
+        var props = base.GetProperties(attributes);
+        var list = new List<PropertyDescriptor>();
+        foreach (PropertyDescriptor pd in props)
+        {
+            if (pd.PropertyType.IsGenericType &&
+                pd.PropertyType.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                if (DrawableCollectionEditor.SupportedCollections.Contains(pd.PropertyType.GetGenericArguments()[0]))
+                {
+                    list.Add(new DrawableCollectionEditorPropertyDescriptor(pd));
+                    continue;
+                }
+            }
+            list.Add(pd);
+        }
+        return new PropertyDescriptorCollection([.. list]);
+    }
+}
+
+public class DrawableCollectionEditorPropertyDescriptor(PropertyDescriptor baseProp) : PropertyDescriptor(baseProp)
+{
+    private readonly PropertyDescriptor _base = baseProp;
+
+    public override Type ComponentType => _base.ComponentType;
+    public override bool IsReadOnly => _base.IsReadOnly;
+    public override Type PropertyType => _base.PropertyType;
+    public override bool CanResetValue(object component) => _base.CanResetValue(component);
+    public override object? GetValue(object? component) => _base.GetValue(component);
+    public override void ResetValue(object component) => _base.ResetValue(component);
+    public override void SetValue(object? component, object? value) => _base.SetValue(component, value);
+    public override bool ShouldSerializeValue(object component) => _base.ShouldSerializeValue(component);
+
+    public override object? GetEditor(Type editorBaseType)
+    {
+        if (editorBaseType == typeof(UITypeEditor))
+            return new DrawableCollectionEditor(_base.PropertyType);
+        return _base.GetEditor(editorBaseType);
+    }
+}

--- a/SysBot.Pokemon.WinForms/Controls/DrawableButton.cs
+++ b/SysBot.Pokemon.WinForms/Controls/DrawableButton.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace SysBot.Pokemon.WinForms;
+
+public class DrawableButton : Button
+{
+    private bool _hovered = false;
+
+    public Color NormalBackColor { get; set; } = Color.FromArgb(48, 48, 48);
+    public Color HoverBackColor { get; set; } = Color.FromArgb(64, 64, 64);
+    public Color BorderColor { get; set; } = Color.FromArgb(100, 100, 100);
+    public int BorderRadius { get; set; } = 5;
+    public int BorderThickness { get; set; } = 1;
+
+    public DrawableButton()
+    {
+        if (Program.IsDarkTheme)
+        {
+            FlatStyle = FlatStyle.Flat;
+            FlatAppearance.BorderSize = 0;
+            BackColor = NormalBackColor;
+            ForeColor = Color.White;
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer, true);
+            Cursor = Cursors.Default;
+        }
+    }
+
+    protected override void OnMouseEnter(EventArgs e)
+    {
+        base.OnMouseEnter(e);
+        if (Program.IsDarkTheme)
+        {
+            _hovered = true;
+            Invalidate();
+        }
+    }
+
+    protected override void OnMouseLeave(EventArgs e)
+    {
+        base.OnMouseLeave(e);
+        if (Program.IsDarkTheme)
+        {
+            _hovered = false;
+            Invalidate();
+        }
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        if (!Program.IsDarkTheme)
+        {
+            base.OnPaint(e);
+            return;
+        }
+
+        Color parentBackColor = Parent?.BackColor ?? Color.FromArgb(32, 32, 32);
+        using (var bg = new SolidBrush(parentBackColor))
+            e.Graphics.FillRectangle(bg, ClientRectangle);
+
+        RectangleF borderRect = new(
+            ClientRectangle.X + 0.5f,
+            ClientRectangle.Y + 0.5f,
+            ClientRectangle.Width - 1f,
+            ClientRectangle.Height - 1f
+        );
+
+        using var path = RoundedRect(borderRect, BorderRadius);
+        e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+        using (var brush = new SolidBrush(_hovered ? HoverBackColor : NormalBackColor))
+            e.Graphics.FillPath(brush, path);
+
+        using (var pen = new Pen(BorderColor, 1f))
+            e.Graphics.DrawPath(pen, path);
+
+        TextRenderer.DrawText(
+            e.Graphics,
+            Text,
+            Font,
+            ClientRectangle,
+            ForeColor,
+            TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter
+        );
+    }
+
+    private static GraphicsPath RoundedRect(RectangleF bounds, int radius)
+    {
+        float r = radius;
+        var path = new GraphicsPath();
+        if (r <= 0)
+        {
+            path.AddRectangle(bounds);
+            return path;
+        }
+        path.AddArc(bounds.X, bounds.Y, r * 2, r * 2, 180, 90);
+        path.AddArc(bounds.Right - r * 2, bounds.Y, r * 2, r * 2, 270, 90);
+        path.AddArc(bounds.Right - r * 2, bounds.Bottom - r * 2, r * 2, r * 2, 0, 90);
+        path.AddArc(bounds.X, bounds.Bottom - r * 2, r * 2, r * 2, 90, 90);
+        path.CloseFigure();
+        return path;
+    }
+}

--- a/SysBot.Pokemon.WinForms/Controls/DrawableButton.cs
+++ b/SysBot.Pokemon.WinForms/Controls/DrawableButton.cs
@@ -9,11 +9,11 @@ public class DrawableButton : Button
 {
     private bool _hovered = false;
 
-    public Color NormalBackColor { get; set; } = Color.FromArgb(48, 48, 48);
-    public Color HoverBackColor { get; set; } = Color.FromArgb(64, 64, 64);
-    public Color BorderColor { get; set; } = Color.FromArgb(100, 100, 100);
-    public int BorderRadius { get; set; } = 5;
-    public int BorderThickness { get; set; } = 1;
+    public static Color NormalBackColor { get; set; } = Color.FromArgb(48, 48, 48);
+    public static Color HoverBackColor { get; set; } = Color.FromArgb(64, 64, 64);
+    public static Color BorderColor { get; set; } = Color.FromArgb(100, 100, 100);
+    public static int BorderRadius { get; set; } = 5;
+    public static int BorderThickness { get; set; } = 1;
 
     public DrawableButton()
     {

--- a/SysBot.Pokemon.WinForms/Controls/DrawableCollectionEditor.cs
+++ b/SysBot.Pokemon.WinForms/Controls/DrawableCollectionEditor.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using System.ComponentModel.Design;
+
+namespace SysBot.Pokemon.WinForms;
+
+public class DrawableCollectionEditor(Type type) : CollectionEditor(type)
+{
+    public static readonly Type[] CollectionContainers =
+    [
+        typeof(RemoteControlAccessList),
+        typeof(LegalitySettings),
+    ];
+
+    public static readonly Type[] SupportedCollections =
+    [
+        typeof(RemoteControlAccess),
+        typeof(PKHeX.Core.GameVersion),
+        typeof(PKHeX.Core.EncounterTypeGroup)
+    ];
+
+    protected override CollectionForm CreateCollectionForm()
+    {
+        var form = base.CreateCollectionForm();
+        if (Program.IsDarkTheme)
+        {
+            foreach (Control control in form.Controls)
+                SetDarkrecursive(control);
+
+            SetListBoxOwnerDraw(form);
+        }
+        return form;
+    }
+
+    private static void SetListBoxOwnerDraw(Control control)
+    {
+        foreach (Control c in control.Controls)
+        {
+            if (c is ListBox lb)
+            {
+                lb.DrawMode = DrawMode.OwnerDrawFixed;
+                lb.DrawItem -= ListBox_DrawItemDark;
+                lb.DrawItem += ListBox_DrawItemDark;
+            }
+            else
+            {
+                SetListBoxOwnerDraw(c);
+            }
+        }
+    }
+
+    private static void SetDarkrecursive(Control control)
+    {
+        if (control is Button btn)
+        {
+            btn.FlatStyle = FlatStyle.Flat;
+            btn.FlatAppearance.BorderSize = 0;
+            btn.BackColor = DrawableButton.NormalBackColor;
+            btn.ForeColor = Color.White;
+        }
+        foreach (Control child in control.Controls)
+            SetDarkrecursive(child);
+    }
+
+    private static void ListBox_DrawItemDark(object? sender, DrawItemEventArgs e)
+    {
+        if (sender is not ListBox lb)
+            return;
+
+        if (e.Index < 0 || e.Index >= lb.Items.Count)
+            return;
+
+        e.DrawBackground();
+
+        int iconSize = Math.Min(e.Bounds.Height - 4, 14);
+        Rectangle iconRect = new(e.Bounds.Left + 2, e.Bounds.Top + (e.Bounds.Height - iconSize) / 2, iconSize, iconSize);
+
+        using (var brush = new SolidBrush(Color.LightGray))
+            e.Graphics.FillRectangle(brush, iconRect);
+
+        using (var pen = new Pen(Color.Gray))
+            e.Graphics.DrawRectangle(pen, iconRect);
+
+        string cardinality = (e.Index + 1).ToString();
+        using var numBrush = new SolidBrush(Color.Black);
+        var numFont = e.Font!;
+        var numSize = e.Graphics.MeasureString(cardinality, numFont);
+        var numPos = new PointF(
+            iconRect.Left + (iconRect.Width - numSize.Width) / 2,
+            iconRect.Top + (iconRect.Height - numSize.Height) / 2
+        );
+        e.Graphics.DrawString(cardinality, numFont, numBrush, numPos);
+
+        string text = lb.Items[e.Index]?.ToString() ?? string.Empty;
+        int textOffset = iconRect.Right + 4;
+        Rectangle textRect = new(textOffset, e.Bounds.Top, e.Bounds.Right - textOffset, e.Bounds.Height);
+        TextRenderer.DrawText(e.Graphics, text, e.Font, textRect, SystemColors.ControlText, TextFormatFlags.VerticalCenter | TextFormatFlags.Left);
+
+        e.DrawFocusRectangle();
+    }
+}

--- a/SysBot.Pokemon.WinForms/Controls/DrawableTabControl.cs
+++ b/SysBot.Pokemon.WinForms/Controls/DrawableTabControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -5,10 +6,44 @@ namespace SysBot.Pokemon.WinForms;
 
 public class DrawableTabControl : TabControl
 {
+    private int _hoveredTabIndex = -1;
+
     public DrawableTabControl()
     {
         DrawMode = TabDrawMode.OwnerDrawFixed;
         SetStyle(ControlStyles.UserPaint, true);
+        this.MouseMove += DrawableTabControl_MouseMove;
+        this.MouseLeave += DrawableTabControl_MouseLeave;
+    }
+
+    private void DrawableTabControl_MouseMove(object? sender, MouseEventArgs e)
+    {
+        for (int i = 0; i < TabCount; i++)
+        {
+            if (GetTabRect(i).Contains(e.Location))
+            {
+                if (_hoveredTabIndex != i)
+                {
+                    _hoveredTabIndex = i;
+                    Invalidate();
+                }
+                return;
+            }
+        }
+        if (_hoveredTabIndex != -1)
+        {
+            _hoveredTabIndex = -1;
+            Invalidate();
+        }
+    }
+
+    private void DrawableTabControl_MouseLeave(object? sender, EventArgs e)
+    {
+        if (_hoveredTabIndex != -1)
+        {
+            _hoveredTabIndex = -1;
+            Invalidate();
+        }
     }
 
     protected override void OnPaint(PaintEventArgs e)
@@ -19,20 +54,16 @@ public class DrawableTabControl : TabControl
         Color pageColor = dark ? Color.FromArgb(32, 32, 32) : Color.White;
         Pen borderPen = dark ? Pens.Black : Pens.Gray;
 
-        // Strip
         int tabHeight = ItemSize.Height;
         Rectangle stripRect = new(0, 0, Width, tabHeight + 2);
         using (var b = new SolidBrush(stripColor))
             e.Graphics.FillRectangle(b, stripRect);
 
-        // Tabs
         for (int i = 0; i < TabCount; i++)
             DrawTab(e.Graphics, i, dark);
 
-        // Lower border
         e.Graphics.DrawLine(borderPen, 0, tabHeight + 1, Width, tabHeight + 1);
 
-        // Page background
         if (SelectedTab != null)
         {
             Rectangle pageRect = DisplayRectangle;
@@ -46,11 +77,14 @@ public class DrawableTabControl : TabControl
     {
         Rectangle rect = GetTabRect(index);
         bool selected = (index == SelectedIndex);
+        bool hovered = (index == _hoveredTabIndex);
 
-        // Tab Colors
         Color tabColor = dark
             ? (selected ? Color.FromArgb(48, 48, 48) : Color.FromArgb(32, 32, 32))
             : (selected ? Color.FromArgb(224, 224, 224) : Color.White);
+
+        if (hovered && !selected)
+            tabColor = dark ? Lighten(tabColor, 0.15f) : Color.FromArgb(240, 240, 240);
 
         Color textColor = dark ? Color.White : Color.Black;
 
@@ -65,5 +99,13 @@ public class DrawableTabControl : TabControl
             textColor,
             TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter
         );
+    }
+
+    private static Color Lighten(Color color, float amount)
+    {
+        int r = color.R + (int)((255 - color.R) * amount);
+        int g = color.G + (int)((255 - color.G) * amount);
+        int b = color.B + (int)((255 - color.B) * amount);
+        return Color.FromArgb(color.A, Math.Min(r, 255), Math.Min(g, 255), Math.Min(b, 255));
     }
 }

--- a/SysBot.Pokemon.WinForms/Controls/DrawableTabControl.cs
+++ b/SysBot.Pokemon.WinForms/Controls/DrawableTabControl.cs
@@ -1,0 +1,69 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SysBot.Pokemon.WinForms;
+
+public class DrawableTabControl : TabControl
+{
+    public DrawableTabControl()
+    {
+        DrawMode = TabDrawMode.OwnerDrawFixed;
+        SetStyle(ControlStyles.UserPaint, true);
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        bool dark = Program.IsDarkTheme;
+
+        Color stripColor = dark ? Color.FromArgb(32, 32, 32) : Color.White;
+        Color pageColor = dark ? Color.FromArgb(32, 32, 32) : Color.White;
+        Pen borderPen = dark ? Pens.Black : Pens.Gray;
+
+        // Strip
+        int tabHeight = ItemSize.Height;
+        Rectangle stripRect = new(0, 0, Width, tabHeight + 2);
+        using (var b = new SolidBrush(stripColor))
+            e.Graphics.FillRectangle(b, stripRect);
+
+        // Tabs
+        for (int i = 0; i < TabCount; i++)
+            DrawTab(e.Graphics, i, dark);
+
+        // Lower border
+        e.Graphics.DrawLine(borderPen, 0, tabHeight + 1, Width, tabHeight + 1);
+
+        // Page background
+        if (SelectedTab != null)
+        {
+            Rectangle pageRect = DisplayRectangle;
+            pageRect.Inflate(2, 2);
+            using var pageBrush = new SolidBrush(pageColor);
+            e.Graphics.FillRectangle(pageBrush, pageRect);
+        }
+    }
+
+    private void DrawTab(Graphics g, int index, bool dark)
+    {
+        Rectangle rect = GetTabRect(index);
+        bool selected = (index == SelectedIndex);
+
+        // Tab Colors
+        Color tabColor = dark
+            ? (selected ? Color.FromArgb(48, 48, 48) : Color.FromArgb(32, 32, 32))
+            : (selected ? Color.FromArgb(224, 224, 224) : Color.White);
+
+        Color textColor = dark ? Color.White : Color.Black;
+
+        using (var b = new SolidBrush(tabColor))
+            g.FillRectangle(b, rect);
+
+        TextRenderer.DrawText(
+            g,
+            TabPages[index].Text,
+            Font,
+            rect,
+            textColor,
+            TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter
+        );
+    }
+}

--- a/SysBot.Pokemon.WinForms/Main.Designer.cs
+++ b/SysBot.Pokemon.WinForms/Main.Designer.cs
@@ -30,21 +30,21 @@ namespace SysBot.Pokemon.WinForms
         /// </summary>
         private void InitializeComponent()
         {
-            TC_Main = new SysBot.Pokemon.WinForms.DrawableTabControl();
+            TC_Main = new DrawableTabControl();
             Tab_Bots = new System.Windows.Forms.TabPage();
             CB_Protocol = new System.Windows.Forms.ComboBox();
             FLP_Bots = new System.Windows.Forms.FlowLayoutPanel();
             TB_IP = new System.Windows.Forms.TextBox();
             CB_Routine = new System.Windows.Forms.ComboBox();
             NUD_Port = new System.Windows.Forms.TextBox();
-            B_New = new System.Windows.Forms.Button();
+            B_New = new SysBot.Pokemon.WinForms.DrawableButton();
             Tab_Hub = new System.Windows.Forms.TabPage();
             PG_Hub = new System.Windows.Forms.PropertyGrid();
             Tab_Logs = new System.Windows.Forms.TabPage();
             RTB_Logs = new System.Windows.Forms.RichTextBox();
-            B_Stop = new System.Windows.Forms.Button();
-            B_Start = new System.Windows.Forms.Button();
-            B_RebootStop = new System.Windows.Forms.Button();
+            B_Stop = new SysBot.Pokemon.WinForms.DrawableButton();
+            B_Start = new SysBot.Pokemon.WinForms.DrawableButton();
+            B_RebootStop = new SysBot.Pokemon.WinForms.DrawableButton();
             TC_Main.SuspendLayout();
             Tab_Bots.SuspendLayout();
             Tab_Hub.SuspendLayout();
@@ -57,11 +57,12 @@ namespace SysBot.Pokemon.WinForms
             TC_Main.Controls.Add(Tab_Hub);
             TC_Main.Controls.Add(Tab_Logs);
             TC_Main.Dock = System.Windows.Forms.DockStyle.Fill;
+            TC_Main.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
             TC_Main.Location = new System.Drawing.Point(0, 0);
-            TC_Main.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            TC_Main.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             TC_Main.Name = "TC_Main";
             TC_Main.SelectedIndex = 0;
-            TC_Main.Size = new System.Drawing.Size(814, 557);
+            TC_Main.Size = new System.Drawing.Size(712, 418);
             TC_Main.TabIndex = 3;
             // 
             // Tab_Bots
@@ -72,10 +73,10 @@ namespace SysBot.Pokemon.WinForms
             Tab_Bots.Controls.Add(CB_Routine);
             Tab_Bots.Controls.Add(NUD_Port);
             Tab_Bots.Controls.Add(B_New);
-            Tab_Bots.Location = new System.Drawing.Point(4, 29);
-            Tab_Bots.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            Tab_Bots.Location = new System.Drawing.Point(4, 25);
+            Tab_Bots.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Tab_Bots.Name = "Tab_Bots";
-            Tab_Bots.Size = new System.Drawing.Size(806, 524);
+            Tab_Bots.Size = new System.Drawing.Size(704, 389);
             Tab_Bots.TabIndex = 0;
             Tab_Bots.Text = "Bots";
             Tab_Bots.UseVisualStyleBackColor = true;
@@ -84,10 +85,10 @@ namespace SysBot.Pokemon.WinForms
             // 
             CB_Protocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             CB_Protocol.FormattingEnabled = true;
-            CB_Protocol.Location = new System.Drawing.Point(330, 8);
-            CB_Protocol.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            CB_Protocol.Location = new System.Drawing.Point(289, 6);
+            CB_Protocol.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CB_Protocol.Name = "CB_Protocol";
-            CB_Protocol.Size = new System.Drawing.Size(76, 28);
+            CB_Protocol.Size = new System.Drawing.Size(67, 23);
             CB_Protocol.TabIndex = 10;
             CB_Protocol.SelectedIndexChanged += CB_Protocol_SelectedIndexChanged;
             // 
@@ -95,20 +96,20 @@ namespace SysBot.Pokemon.WinForms
             // 
             FLP_Bots.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Bots.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            FLP_Bots.Location = new System.Drawing.Point(0, 49);
+            FLP_Bots.Location = new System.Drawing.Point(0, 37);
             FLP_Bots.Margin = new System.Windows.Forms.Padding(0);
             FLP_Bots.Name = "FLP_Bots";
-            FLP_Bots.Size = new System.Drawing.Size(804, 466);
+            FLP_Bots.Size = new System.Drawing.Size(704, 350);
             FLP_Bots.TabIndex = 9;
             FLP_Bots.Resize += FLP_Bots_Resize;
             // 
             // TB_IP
             // 
             TB_IP.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
-            TB_IP.Location = new System.Drawing.Point(85, 11);
-            TB_IP.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            TB_IP.Location = new System.Drawing.Point(74, 8);
+            TB_IP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             TB_IP.Name = "TB_IP";
-            TB_IP.Size = new System.Drawing.Size(153, 23);
+            TB_IP.Size = new System.Drawing.Size(134, 20);
             TB_IP.TabIndex = 8;
             TB_IP.Text = "192.168.0.1";
             // 
@@ -116,29 +117,28 @@ namespace SysBot.Pokemon.WinForms
             // 
             CB_Routine.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             CB_Routine.FormattingEnabled = true;
-            CB_Routine.Location = new System.Drawing.Point(416, 8);
-            CB_Routine.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            CB_Routine.Location = new System.Drawing.Point(364, 6);
+            CB_Routine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CB_Routine.Name = "CB_Routine";
-            CB_Routine.Size = new System.Drawing.Size(133, 28);
+            CB_Routine.Size = new System.Drawing.Size(117, 23);
             CB_Routine.TabIndex = 7;
             // 
             // NUD_Port
             // 
             NUD_Port.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
-            NUD_Port.Location = new System.Drawing.Point(246, 11);
-            NUD_Port.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            NUD_Port.Location = new System.Drawing.Point(215, 8);
+            NUD_Port.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Port.Name = "NUD_Port";
-            NUD_Port.ReadOnly = true;
-            NUD_Port.Size = new System.Drawing.Size(76, 23);
+            NUD_Port.Size = new System.Drawing.Size(67, 20);
             NUD_Port.TabIndex = 6;
             NUD_Port.Text = "6000";
             // 
             // B_New
             // 
-            B_New.Location = new System.Drawing.Point(5, 9);
-            B_New.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            B_New.Location = new System.Drawing.Point(4, 7);
+            B_New.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             B_New.Name = "B_New";
-            B_New.Size = new System.Drawing.Size(72, 31);
+            B_New.Size = new System.Drawing.Size(63, 23);
             B_New.TabIndex = 0;
             B_New.Text = "Add";
             B_New.UseVisualStyleBackColor = true;
@@ -147,11 +147,11 @@ namespace SysBot.Pokemon.WinForms
             // Tab_Hub
             // 
             Tab_Hub.Controls.Add(PG_Hub);
-            Tab_Hub.Location = new System.Drawing.Point(4, 29);
-            Tab_Hub.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            Tab_Hub.Location = new System.Drawing.Point(4, 25);
+            Tab_Hub.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Tab_Hub.Name = "Tab_Hub";
-            Tab_Hub.Padding = new System.Windows.Forms.Padding(5, 4, 5, 4);
-            Tab_Hub.Size = new System.Drawing.Size(806, 524);
+            Tab_Hub.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Tab_Hub.Size = new System.Drawing.Size(704, 389);
             Tab_Hub.TabIndex = 2;
             Tab_Hub.Text = "Hub";
             Tab_Hub.UseVisualStyleBackColor = true;
@@ -160,43 +160,44 @@ namespace SysBot.Pokemon.WinForms
             // 
             PG_Hub.BackColor = System.Drawing.SystemColors.Control;
             PG_Hub.Dock = System.Windows.Forms.DockStyle.Fill;
-            PG_Hub.Location = new System.Drawing.Point(5, 4);
-            PG_Hub.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            PG_Hub.Location = new System.Drawing.Point(4, 3);
+            PG_Hub.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             PG_Hub.Name = "PG_Hub";
             PG_Hub.PropertySort = System.Windows.Forms.PropertySort.Categorized;
-            PG_Hub.Size = new System.Drawing.Size(796, 516);
+            PG_Hub.Size = new System.Drawing.Size(696, 383);
             PG_Hub.TabIndex = 0;
             // 
             // Tab_Logs
             // 
             Tab_Logs.Controls.Add(RTB_Logs);
-            Tab_Logs.Location = new System.Drawing.Point(4, 29);
-            Tab_Logs.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            Tab_Logs.Location = new System.Drawing.Point(4, 25);
+            Tab_Logs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Tab_Logs.Name = "Tab_Logs";
-            Tab_Logs.Size = new System.Drawing.Size(806, 524);
+            Tab_Logs.Size = new System.Drawing.Size(704, 389);
             Tab_Logs.TabIndex = 1;
             Tab_Logs.Text = "Logs";
             Tab_Logs.UseVisualStyleBackColor = true;
             // 
             // RTB_Logs
             // 
+            RTB_Logs.BorderStyle = System.Windows.Forms.BorderStyle.None;
             RTB_Logs.Dock = System.Windows.Forms.DockStyle.Fill;
             RTB_Logs.HideSelection = false;
             RTB_Logs.Location = new System.Drawing.Point(0, 0);
-            RTB_Logs.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            RTB_Logs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             RTB_Logs.Name = "RTB_Logs";
             RTB_Logs.ReadOnly = true;
-            RTB_Logs.Size = new System.Drawing.Size(806, 524);
+            RTB_Logs.Size = new System.Drawing.Size(704, 389);
             RTB_Logs.TabIndex = 0;
             RTB_Logs.Text = "";
             // 
             // B_Stop
             // 
             B_Stop.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_Stop.Location = new System.Drawing.Point(566, 0);
-            B_Stop.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            B_Stop.Location = new System.Drawing.Point(495, 0);
+            B_Stop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             B_Stop.Name = "B_Stop";
-            B_Stop.Size = new System.Drawing.Size(79, 31);
+            B_Stop.Size = new System.Drawing.Size(69, 22);
             B_Stop.TabIndex = 4;
             B_Stop.Text = "Stop All";
             B_Stop.UseVisualStyleBackColor = true;
@@ -205,10 +206,10 @@ namespace SysBot.Pokemon.WinForms
             // B_Start
             // 
             B_Start.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_Start.Location = new System.Drawing.Point(471, 0);
-            B_Start.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            B_Start.Location = new System.Drawing.Point(412, 0);
+            B_Start.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             B_Start.Name = "B_Start";
-            B_Start.Size = new System.Drawing.Size(79, 31);
+            B_Start.Size = new System.Drawing.Size(69, 22);
             B_Start.TabIndex = 3;
             B_Start.Text = "Start All";
             B_Start.UseVisualStyleBackColor = true;
@@ -217,10 +218,10 @@ namespace SysBot.Pokemon.WinForms
             // B_RebootStop
             // 
             B_RebootStop.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_RebootStop.Location = new System.Drawing.Point(661, 0);
-            B_RebootStop.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            B_RebootStop.Location = new System.Drawing.Point(578, 0);
+            B_RebootStop.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             B_RebootStop.Name = "B_RebootStop";
-            B_RebootStop.Size = new System.Drawing.Size(138, 31);
+            B_RebootStop.Size = new System.Drawing.Size(121, 22);
             B_RebootStop.TabIndex = 3;
             B_RebootStop.Text = "Reboot And Stop";
             B_RebootStop.UseVisualStyleBackColor = true;
@@ -228,15 +229,15 @@ namespace SysBot.Pokemon.WinForms
             // 
             // Main
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(814, 557);
+            ClientSize = new System.Drawing.Size(712, 418);
             Controls.Add(B_Stop);
             Controls.Add(B_Start);
             Controls.Add(B_RebootStop);
             Controls.Add(TC_Main);
             Icon = Resources.icon;
-            Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Name = "Main";
             StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             Text = "ManuBot: Pokémon";
@@ -257,13 +258,13 @@ namespace SysBot.Pokemon.WinForms
         private System.Windows.Forms.RichTextBox RTB_Logs;
         private System.Windows.Forms.TabPage Tab_Hub;
         private System.Windows.Forms.PropertyGrid PG_Hub;
-        private System.Windows.Forms.Button B_Stop;
-        private System.Windows.Forms.Button B_Start;
-        private System.Windows.Forms.Button B_RebootStop;
+        private SysBot.Pokemon.WinForms.DrawableButton B_Stop;
+        private SysBot.Pokemon.WinForms.DrawableButton B_Start;
+        private SysBot.Pokemon.WinForms.DrawableButton B_RebootStop;
         private System.Windows.Forms.TextBox TB_IP;
         private System.Windows.Forms.ComboBox CB_Routine;
         private System.Windows.Forms.TextBox NUD_Port;
-        private System.Windows.Forms.Button B_New;
+        private SysBot.Pokemon.WinForms.DrawableButton B_New;
         private System.Windows.Forms.FlowLayoutPanel FLP_Bots;
         private System.Windows.Forms.ComboBox CB_Protocol;
     }

--- a/SysBot.Pokemon.WinForms/Main.Designer.cs
+++ b/SysBot.Pokemon.WinForms/Main.Designer.cs
@@ -30,7 +30,7 @@ namespace SysBot.Pokemon.WinForms
         /// </summary>
         private void InitializeComponent()
         {
-            TC_Main = new System.Windows.Forms.TabControl();
+            TC_Main = new SysBot.Pokemon.WinForms.DrawableTabControl();
             Tab_Bots = new System.Windows.Forms.TabPage();
             CB_Protocol = new System.Windows.Forms.ComboBox();
             FLP_Bots = new System.Windows.Forms.FlowLayoutPanel();
@@ -58,10 +58,10 @@ namespace SysBot.Pokemon.WinForms
             TC_Main.Controls.Add(Tab_Logs);
             TC_Main.Dock = System.Windows.Forms.DockStyle.Fill;
             TC_Main.Location = new System.Drawing.Point(0, 0);
-            TC_Main.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            TC_Main.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             TC_Main.Name = "TC_Main";
             TC_Main.SelectedIndex = 0;
-            TC_Main.Size = new System.Drawing.Size(712, 418);
+            TC_Main.Size = new System.Drawing.Size(814, 557);
             TC_Main.TabIndex = 3;
             // 
             // Tab_Bots
@@ -72,10 +72,10 @@ namespace SysBot.Pokemon.WinForms
             Tab_Bots.Controls.Add(CB_Routine);
             Tab_Bots.Controls.Add(NUD_Port);
             Tab_Bots.Controls.Add(B_New);
-            Tab_Bots.Location = new System.Drawing.Point(4, 24);
-            Tab_Bots.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Tab_Bots.Location = new System.Drawing.Point(4, 29);
+            Tab_Bots.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             Tab_Bots.Name = "Tab_Bots";
-            Tab_Bots.Size = new System.Drawing.Size(704, 390);
+            Tab_Bots.Size = new System.Drawing.Size(806, 524);
             Tab_Bots.TabIndex = 0;
             Tab_Bots.Text = "Bots";
             Tab_Bots.UseVisualStyleBackColor = true;
@@ -84,10 +84,10 @@ namespace SysBot.Pokemon.WinForms
             // 
             CB_Protocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             CB_Protocol.FormattingEnabled = true;
-            CB_Protocol.Location = new System.Drawing.Point(289, 6);
-            CB_Protocol.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            CB_Protocol.Location = new System.Drawing.Point(330, 8);
+            CB_Protocol.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             CB_Protocol.Name = "CB_Protocol";
-            CB_Protocol.Size = new System.Drawing.Size(67, 23);
+            CB_Protocol.Size = new System.Drawing.Size(76, 28);
             CB_Protocol.TabIndex = 10;
             CB_Protocol.SelectedIndexChanged += CB_Protocol_SelectedIndexChanged;
             // 
@@ -95,20 +95,20 @@ namespace SysBot.Pokemon.WinForms
             // 
             FLP_Bots.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Bots.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            FLP_Bots.Location = new System.Drawing.Point(0, 37);
+            FLP_Bots.Location = new System.Drawing.Point(0, 49);
             FLP_Bots.Margin = new System.Windows.Forms.Padding(0);
             FLP_Bots.Name = "FLP_Bots";
-            FLP_Bots.Size = new System.Drawing.Size(704, 350);
+            FLP_Bots.Size = new System.Drawing.Size(804, 466);
             FLP_Bots.TabIndex = 9;
             FLP_Bots.Resize += FLP_Bots_Resize;
             // 
             // TB_IP
             // 
             TB_IP.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
-            TB_IP.Location = new System.Drawing.Point(74, 8);
-            TB_IP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            TB_IP.Location = new System.Drawing.Point(85, 11);
+            TB_IP.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             TB_IP.Name = "TB_IP";
-            TB_IP.Size = new System.Drawing.Size(134, 20);
+            TB_IP.Size = new System.Drawing.Size(153, 23);
             TB_IP.TabIndex = 8;
             TB_IP.Text = "192.168.0.1";
             // 
@@ -116,29 +116,29 @@ namespace SysBot.Pokemon.WinForms
             // 
             CB_Routine.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             CB_Routine.FormattingEnabled = true;
-            CB_Routine.Location = new System.Drawing.Point(364, 6);
-            CB_Routine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            CB_Routine.Location = new System.Drawing.Point(416, 8);
+            CB_Routine.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             CB_Routine.Name = "CB_Routine";
-            CB_Routine.Size = new System.Drawing.Size(117, 23);
+            CB_Routine.Size = new System.Drawing.Size(133, 28);
             CB_Routine.TabIndex = 7;
             // 
             // NUD_Port
             // 
             NUD_Port.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
-            NUD_Port.Location = new System.Drawing.Point(215, 8);
-            NUD_Port.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Port.Location = new System.Drawing.Point(246, 11);
+            NUD_Port.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             NUD_Port.Name = "NUD_Port";
             NUD_Port.ReadOnly = true;
-            NUD_Port.Size = new System.Drawing.Size(67, 20);
+            NUD_Port.Size = new System.Drawing.Size(76, 23);
             NUD_Port.TabIndex = 6;
             NUD_Port.Text = "6000";
             // 
             // B_New
             // 
-            B_New.Location = new System.Drawing.Point(4, 7);
-            B_New.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_New.Location = new System.Drawing.Point(5, 9);
+            B_New.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             B_New.Name = "B_New";
-            B_New.Size = new System.Drawing.Size(63, 23);
+            B_New.Size = new System.Drawing.Size(72, 31);
             B_New.TabIndex = 0;
             B_New.Text = "Add";
             B_New.UseVisualStyleBackColor = true;
@@ -147,11 +147,11 @@ namespace SysBot.Pokemon.WinForms
             // Tab_Hub
             // 
             Tab_Hub.Controls.Add(PG_Hub);
-            Tab_Hub.Location = new System.Drawing.Point(4, 24);
-            Tab_Hub.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Tab_Hub.Location = new System.Drawing.Point(4, 29);
+            Tab_Hub.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             Tab_Hub.Name = "Tab_Hub";
-            Tab_Hub.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            Tab_Hub.Size = new System.Drawing.Size(704, 340);
+            Tab_Hub.Padding = new System.Windows.Forms.Padding(5, 4, 5, 4);
+            Tab_Hub.Size = new System.Drawing.Size(806, 524);
             Tab_Hub.TabIndex = 2;
             Tab_Hub.Text = "Hub";
             Tab_Hub.UseVisualStyleBackColor = true;
@@ -160,20 +160,20 @@ namespace SysBot.Pokemon.WinForms
             // 
             PG_Hub.BackColor = System.Drawing.SystemColors.Control;
             PG_Hub.Dock = System.Windows.Forms.DockStyle.Fill;
-            PG_Hub.Location = new System.Drawing.Point(4, 3);
-            PG_Hub.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            PG_Hub.Location = new System.Drawing.Point(5, 4);
+            PG_Hub.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             PG_Hub.Name = "PG_Hub";
             PG_Hub.PropertySort = System.Windows.Forms.PropertySort.Categorized;
-            PG_Hub.Size = new System.Drawing.Size(696, 334);
+            PG_Hub.Size = new System.Drawing.Size(796, 516);
             PG_Hub.TabIndex = 0;
             // 
             // Tab_Logs
             // 
             Tab_Logs.Controls.Add(RTB_Logs);
-            Tab_Logs.Location = new System.Drawing.Point(4, 24);
-            Tab_Logs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Tab_Logs.Location = new System.Drawing.Point(4, 29);
+            Tab_Logs.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             Tab_Logs.Name = "Tab_Logs";
-            Tab_Logs.Size = new System.Drawing.Size(704, 340);
+            Tab_Logs.Size = new System.Drawing.Size(806, 524);
             Tab_Logs.TabIndex = 1;
             Tab_Logs.Text = "Logs";
             Tab_Logs.UseVisualStyleBackColor = true;
@@ -183,20 +183,20 @@ namespace SysBot.Pokemon.WinForms
             RTB_Logs.Dock = System.Windows.Forms.DockStyle.Fill;
             RTB_Logs.HideSelection = false;
             RTB_Logs.Location = new System.Drawing.Point(0, 0);
-            RTB_Logs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            RTB_Logs.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             RTB_Logs.Name = "RTB_Logs";
             RTB_Logs.ReadOnly = true;
-            RTB_Logs.Size = new System.Drawing.Size(704, 340);
+            RTB_Logs.Size = new System.Drawing.Size(806, 524);
             RTB_Logs.TabIndex = 0;
             RTB_Logs.Text = "";
             // 
             // B_Stop
             // 
             B_Stop.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_Stop.Location = new System.Drawing.Point(495, 0);
-            B_Stop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_Stop.Location = new System.Drawing.Point(566, 0);
+            B_Stop.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             B_Stop.Name = "B_Stop";
-            B_Stop.Size = new System.Drawing.Size(69, 23);
+            B_Stop.Size = new System.Drawing.Size(79, 31);
             B_Stop.TabIndex = 4;
             B_Stop.Text = "Stop All";
             B_Stop.UseVisualStyleBackColor = true;
@@ -205,10 +205,10 @@ namespace SysBot.Pokemon.WinForms
             // B_Start
             // 
             B_Start.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_Start.Location = new System.Drawing.Point(412, 0);
-            B_Start.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            B_Start.Location = new System.Drawing.Point(471, 0);
+            B_Start.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             B_Start.Name = "B_Start";
-            B_Start.Size = new System.Drawing.Size(69, 23);
+            B_Start.Size = new System.Drawing.Size(79, 31);
             B_Start.TabIndex = 3;
             B_Start.Text = "Start All";
             B_Start.UseVisualStyleBackColor = true;
@@ -217,10 +217,10 @@ namespace SysBot.Pokemon.WinForms
             // B_RebootStop
             // 
             B_RebootStop.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            B_RebootStop.Location = new System.Drawing.Point(578, 0);
-            B_RebootStop.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            B_RebootStop.Location = new System.Drawing.Point(661, 0);
+            B_RebootStop.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             B_RebootStop.Name = "B_RebootStop";
-            B_RebootStop.Size = new System.Drawing.Size(121, 23);
+            B_RebootStop.Size = new System.Drawing.Size(138, 31);
             B_RebootStop.TabIndex = 3;
             B_RebootStop.Text = "Reboot And Stop";
             B_RebootStop.UseVisualStyleBackColor = true;
@@ -228,15 +228,15 @@ namespace SysBot.Pokemon.WinForms
             // 
             // Main
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(712, 418);
+            ClientSize = new System.Drawing.Size(814, 557);
             Controls.Add(B_Stop);
             Controls.Add(B_Start);
             Controls.Add(B_RebootStop);
             Controls.Add(TC_Main);
             Icon = Resources.icon;
-            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             Name = "Main";
             StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             Text = "ManuBot: Pokémon";
@@ -251,7 +251,7 @@ namespace SysBot.Pokemon.WinForms
         }
 
         #endregion
-        private System.Windows.Forms.TabControl TC_Main;
+        private SysBot.Pokemon.WinForms.DrawableTabControl TC_Main;
         private System.Windows.Forms.TabPage Tab_Bots;
         private System.Windows.Forms.TabPage Tab_Logs;
         private System.Windows.Forms.RichTextBox RTB_Logs;

--- a/SysBot.Pokemon.WinForms/Main.cs
+++ b/SysBot.Pokemon.WinForms/Main.cs
@@ -35,9 +35,12 @@ public sealed partial class Main : Form
 
         if (Program.IsDarkTheme)
         {
-            Tab_Bots.BackColor = Color.FromArgb(32, 32, 32);
-            Tab_Logs.BackColor = Color.FromArgb(32, 32, 32);
-            Tab_Hub.BackColor = Color.FromArgb(32, 32, 32);
+
+            foreach (var tab in new[] { Tab_Bots, Tab_Logs, Tab_Hub })
+                tab.BackColor = Color.FromArgb(32, 32, 32);
+
+            foreach (var text in new[] { TB_IP, NUD_Port })
+                text.BorderStyle = BorderStyle.FixedSingle;
         }
 
         RTB_Logs.MaxLength = 32_767; // character length
@@ -292,7 +295,7 @@ public sealed partial class Main : Form
     {
         var isWifi = CB_Protocol.SelectedIndex == 0;
         TB_IP.Visible = isWifi;
-        NUD_Port.ReadOnly = isWifi;
+        //NUD_Port.ReadOnly = isWifi;
 
         if (isWifi)
             NUD_Port.Text = "6000";

--- a/SysBot.Pokemon.WinForms/Main.cs
+++ b/SysBot.Pokemon.WinForms/Main.cs
@@ -19,34 +19,26 @@ public sealed partial class Main : Form
     private readonly IPokeBotRunner RunningEnvironment;
     private readonly ProgramConfig Config;
 
-    public Main()
+    public Main(ProgramConfig config)
     {
         InitializeComponent();
 
+        Config = config;
         PokeTradeBotSWSH.SeedChecker = new Z3SeedSearchHandler<PK8>();
-        if (File.Exists(Program.ConfigPath))
-        {
-            var lines = File.ReadAllText(Program.ConfigPath);
-            Config = JsonSerializer.Deserialize(lines, ProgramConfigContext.Default.ProgramConfig) ?? new ProgramConfig();
-            LogConfig.MaxArchiveFiles = Config.Hub.MaxArchiveFiles;
-            LogConfig.LoggingEnabled = Config.Hub.LoggingEnabled;
+        RunningEnvironment = GetRunner(Config);
 
-            RunningEnvironment = GetRunner(Config);
-            foreach (var bot in Config.Bots)
-            {
-                bot.Initialize();
-                AddBot(bot);
-            }
-        }
-        else
+        foreach (var bot in Config.Bots)
         {
-            Config = new ProgramConfig();
-            RunningEnvironment = GetRunner(Config);
-            Config.Hub.Folder.CreateDefaults(Program.WorkingDirectory);
+            bot.Initialize();
+            AddBot(bot);
         }
 
-        if (Program.IsDarkThemeSet(Config))
-            ApplyControlDarkMode(this);
+        if (Program.IsDarkTheme)
+        {
+            Tab_Bots.BackColor = Color.FromArgb(32, 32, 32);
+            Tab_Logs.BackColor = Color.FromArgb(32, 32, 32);
+            Tab_Hub.BackColor = Color.FromArgb(32, 32, 32);
+        }
 
         RTB_Logs.MaxLength = 32_767; // character length
         LoadControls();
@@ -304,25 +296,5 @@ public sealed partial class Main : Form
 
         if (isWifi)
             NUD_Port.Text = "6000";
-    }
-
-    private static readonly Type[] ForceDarkControls =
-    {
-        typeof(TabPage),
-        typeof(Panel)
-    };
-
-    private void ApplyControlDarkMode(Control control)
-    {
-        const int Dark = 32;
-
-        if (ForceDarkControls.Contains(control.GetType()))
-        {
-            control.BackColor = Color.FromArgb(Dark, Dark, Dark);
-            control.ForeColor = Color.White;
-        }
-
-        foreach (Control child in control.Controls)
-            ApplyControlDarkMode(child);
     }
 }

--- a/SysBot.Pokemon.WinForms/Main.cs
+++ b/SysBot.Pokemon.WinForms/Main.cs
@@ -295,6 +295,7 @@ public sealed partial class Main : Form
     {
         var isWifi = CB_Protocol.SelectedIndex == 0;
         TB_IP.Visible = isWifi;
+        NUD_Port.Visible = !isWifi;
         //NUD_Port.ReadOnly = isWifi;
 
         if (isWifi)

--- a/SysBot.Pokemon.WinForms/Main.cs
+++ b/SysBot.Pokemon.WinForms/Main.cs
@@ -3,13 +3,13 @@ using SysBot.Base;
 using SysBot.Pokemon.Z3;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.ListView;
 
 namespace SysBot.Pokemon.WinForms;
 
@@ -44,6 +44,9 @@ public sealed partial class Main : Form
             RunningEnvironment = GetRunner(Config);
             Config.Hub.Folder.CreateDefaults(Program.WorkingDirectory);
         }
+
+        if (Program.IsDarkThemeSet(Config))
+            ApplyControlDarkMode(this);
 
         RTB_Logs.MaxLength = 32_767; // character length
         LoadControls();
@@ -301,5 +304,25 @@ public sealed partial class Main : Form
 
         if (isWifi)
             NUD_Port.Text = "6000";
+    }
+
+    private static readonly Type[] ForceDarkControls =
+    {
+        typeof(TabPage),
+        typeof(Panel)
+    };
+
+    private void ApplyControlDarkMode(Control control)
+    {
+        const int Dark = 32;
+
+        if (ForceDarkControls.Contains(control.GetType()))
+        {
+            control.BackColor = Color.FromArgb(Dark, Dark, Dark);
+            control.ForeColor = Color.White;
+        }
+
+        foreach (Control child in control.Controls)
+            ApplyControlDarkMode(child);
     }
 }

--- a/SysBot.Pokemon.WinForms/Main.cs
+++ b/SysBot.Pokemon.WinForms/Main.cs
@@ -301,4 +301,54 @@ public sealed partial class Main : Form
         if (isWifi)
             NUD_Port.Text = "6000";
     }
+
+    protected override void OnLoad(EventArgs e)
+    {
+        base.OnLoad(e);
+        CenterTopButtons();
+    }
+
+    protected override void OnResize(EventArgs e)
+    {
+        base.OnResize(e);
+        CenterTopButtons();
+    }
+
+    private void CenterTopButtons()
+    {
+        int topLine = TC_Main.Top;
+        int tabHeaderHeight = TC_Main.DisplayRectangle.Top;
+        int bottomLine = topLine + tabHeaderHeight;
+        int availableHeight = bottomLine - topLine;
+
+        int minButtonHeight = 22;
+        float minFontSize = 6f;
+
+        void CenterResizeAndFontButton(Button btn)
+        {
+            if (btn.Tag is not Font originalFont)
+            {
+                originalFont = btn.Font;
+                btn.Tag = originalFont;
+            }
+
+            int targetHeight = Math.Min(originalFont.Height, availableHeight);
+            if (targetHeight < minButtonHeight)
+                targetHeight = minButtonHeight;
+
+            btn.Height = targetHeight;
+
+            float scale = (float)targetHeight / originalFont.Height;
+            float fontSize = Math.Max(minFontSize, Math.Min(originalFont.Size * scale, originalFont.Size));
+
+            if (Math.Abs(btn.Font.Size - fontSize) > 0.5f)
+                btn.Font = new Font(originalFont.FontFamily, fontSize, originalFont.Style);
+
+            btn.Top = topLine + (availableHeight - btn.Height) / 2;
+        }
+
+        CenterResizeAndFontButton(B_Start);
+        CenterResizeAndFontButton(B_Stop);
+        CenterResizeAndFontButton(B_RebootStop);
+    }
 }

--- a/SysBot.Pokemon.WinForms/Program.cs
+++ b/SysBot.Pokemon.WinForms/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using Microsoft.Win32;
+using System.Text.Json;
 using System.Windows.Forms;
 
 namespace SysBot.Pokemon.WinForms;
@@ -23,8 +25,38 @@ internal static class Program
         if (cfg != null)
             ConfigPath = cmd[0];
 
+
         Application.EnableVisualStyles();
+
+#pragma warning disable WFO5001
+        if (IsDarkThemeSet())
+            Application.SetColorMode(SystemColorMode.Dark);
+#pragma warning restore WFO5001
+
         Application.SetCompatibleTextRenderingDefault(false);
         Application.Run(new Main());
+    }
+
+    public static bool IsDarkThemeSet(ProgramConfig? config = null)
+    {
+        config ??= (File.Exists(ConfigPath)) switch
+        {
+            true => JsonSerializer.Deserialize(File.ReadAllText(ConfigPath),
+                WinForms.Main.ProgramConfigContext.Default.ProgramConfig) ?? new ProgramConfig(),
+            false => new ProgramConfig()
+        };
+
+        return (config.Hub.ColorTheme is BaseConfig.SystemColorTheme.Dark ||
+            (config.Hub.ColorTheme is BaseConfig.SystemColorTheme.System &&
+            GetFromRegistry() is BaseConfig.SystemColorTheme.Dark));
+
+        static BaseConfig.SystemColorTheme GetFromRegistry()
+        {
+            const string keyPath = @"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+            using var key = Registry.CurrentUser.OpenSubKey(keyPath);
+            if (key?.GetValue("AppsUseLightTheme") is int value)
+                return value == 0 ? BaseConfig.SystemColorTheme.Dark : BaseConfig.SystemColorTheme.Light;
+            return BaseConfig.SystemColorTheme.Light;
+        }
     }
 }

--- a/SysBot.Pokemon.WinForms/Program.cs
+++ b/SysBot.Pokemon.WinForms/Program.cs
@@ -1,9 +1,10 @@
-using Microsoft.Win32;
-using SysBot.Base;
 using System;
 using System.IO;
+using SysBot.Base;
+using Microsoft.Win32;
 using System.Text.Json;
 using System.Windows.Forms;
+using System.ComponentModel;
 
 namespace SysBot.Pokemon.WinForms;
 
@@ -28,6 +29,10 @@ internal static class Program
             ConfigPath = cmd[0];
 
         var config = InitConfig();
+
+        foreach (var container in DrawableCollectionEditor.CollectionContainers)
+            TypeDescriptor.AddProvider(new CollectionDescriptionProvider(container), container);
+
         Application.EnableVisualStyles();
 #pragma warning disable WFO5001
         if (IsDarkThemeSet(config))

--- a/SysBot.Pokemon/Settings/BaseConfig.cs
+++ b/SysBot.Pokemon/Settings/BaseConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace SysBot.Pokemon;
 
@@ -20,6 +20,9 @@ public abstract class BaseConfig
     [Category(FeatureToggle), Description("Maximum number of old text log files to retain. Set this to <= 0 to disable log cleanup. Restart to apply changes.")]
     public int MaxArchiveFiles { get; set; } = 14;
 
+    [Category(FeatureToggle), Description("Program theme. 'Classic' uses the white theme, 'System' follows your Windows default theme, and 'Dark' enables a dark theme. If you're not on Windows 11, it's recommended to leave it on 'System'. Restart to apply changes.")]
+    public SystemColorTheme ColorTheme { get; set; } = SystemColorTheme.System;
+
     [Category(Debug), Description("Skips creating bots when the program is started; helpful for testing integrations.")]
     public bool SkipConsoleBotCreation { get; set; }
 
@@ -32,4 +35,11 @@ public abstract class BaseConfig
     public FolderSettings Folder { get; set; } = new();
 
     public abstract bool Shuffled { get; }
+
+    public enum SystemColorTheme
+    {
+        Light = 0,
+        System = 1,
+        Dark = 2,
+    }
 }


### PR DESCRIPTION
### Dark Mode Support

* Introduces an experimental dark mode.
* Custom subclasses have been implemented for problematic controls to improve appearance under dark themes.
* Several controls have been optimized for better rendering on high-DPI monitors.
* Theme selection is available via: `Hub -> FeatureToggle -> ColorTheme`.

**Available Themes:**

* `Classic`: Default light theme.
* `System`: Follows the OS theme setting (only supported on Windows 11; Windows 10 defaults to Classic).
* `Dark`: Enables dark theme manually.

> ⚠️ While dark mode should function on Windows 10, some minor visual inconsistencies may occur.
